### PR TITLE
VTexplain topology only uses serving shards

### DIFF
--- a/go/vt/vtexplain/vtexplain_vtgate.go
+++ b/go/vt/vtexplain/vtexplain_vtgate.go
@@ -131,6 +131,14 @@ func (vte *VTExplain) buildTopology(opts *Options, vschemaStr string, ksShardMap
 		vte.explainTopo.KeyspaceShards[ks] = make(map[string]*topodatapb.ShardReference)
 
 		for _, shard := range shards {
+			// If the topology is in the middle of a reshard, there can be two shards covering the same key range (e.g.
+			// both source shard 80- and target shard 80-c0 cover the keyrange 80-c0). For the purposes of explain, we
+			// should only consider the one that is serving, hence we skip the ones not serving. Otherwise, vtexplain
+			// gives inconsistent results - sometimes it will route the query being explained to the source shard, and
+			// sometimes to the destination shard. See https://github.com/vitessio/vitess/issues/11632 .
+			if !ksShardMap[ks][shard.Name].IsPrimaryServing {
+				continue
+			}
 			hostname := fmt.Sprintf("%s/%s", ks, shard.Name)
 			log.Infof("registering test tablet %s for keyspace %s shard %s", hostname, ks, shard.Name)
 


### PR DESCRIPTION
## Description
This addresses issue https://github.com/vitessio/vitess/issues/11632 , which causes vtexplain to sometimes give bad results if the keyspace is being resharded, because sometimes it picks source shards and other times target shards, for routing the query.

The issue is that the `VTExplain.buildTopolog()` adds both source and destination shards to the map that holds shards per keyspace, when only one of them is actually serving traffic at any point in time. Later on, vtexplain loops over this map. Because looping over the map gives a non-deterministic order, sometimes the results are correct, and sometimes incorrect - that is, sometimes it gives the result of the shard that is serving, and other times, the shard that is not serving.

This change ensures that only the serving shards are added to the shards per keyspace map, thus avoiding the incorrect vtexplain.

Signed-off-by: Eduardo J. Ortega U. <eduardo.ortega@slack-corp.com>

## Related Issue(s)
https://github.com/vitessio/vitess/issues/11632

## Checklist

-   [ ] "Backport me!" label has been added if this change should be backported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes
N/A